### PR TITLE
Use core instead of std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,10 +49,10 @@
 //! }
 //! ```
 
-use std::cmp::PartialEq;
-use std::iter::Iterator;
-use std::num::Wrapping as Wr;
-use std::ops::{Range, Shl, Shr, Not, BitAnd, BitOr};
+use core::cmp::PartialEq;
+use core::iter::Iterator;
+use core::num::Wrapping as Wr;
+use core::ops::{Range, Shl, Shr, Not, BitAnd, BitOr};
 
 /// A trait for bit-twiddling utility functions.
 pub trait Twiddle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@
 //! }
 //! ```
 
+#![no_std]
+
 use core::cmp::PartialEq;
 use core::iter::Iterator;
 use core::num::Wrapping as Wr;


### PR DESCRIPTION
This enables building in freestanding environments.
