### PR TITLE
Make Int trait methods inlinable across crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,9 +233,13 @@ pub trait Int:
 macro_rules! impl_int {
     ($($t:ty : $w:expr, $z:expr, $o:expr);*) => ($(
         impl Int for $t {
+            #[inline]
             fn bit_width() -> usize { $w }
+            #[inline]
             fn zero() -> Self { $z }
+            #[inline]
             fn one() -> Self { $o }
+            #[inline]
             fn cshl(self, n: usize) -> Self {
                 self.checked_shl(n as u32).unwrap_or(0)
             }


### PR DESCRIPTION
Currently, the `Twiddle` methods themselves are inlinable as they use generics, but the `Int` methods are not.
Since they are so tiny, having the compiler be able to inline them would be desirable.